### PR TITLE
Corrections to RF-02_ActionBar.md

### DIFF
--- a/(C)Requirements/FunctionalRequirements/RF-02_ActionBar.md
+++ b/(C)Requirements/FunctionalRequirements/RF-02_ActionBar.md
@@ -28,35 +28,44 @@
 
 ### Home
 - The user can access this section through the central button.
-- In this section, items are displayed that can contain platforms (<span style="color:#CE9178;">item.platmform</span>) or courses from these platforms (<span style="color:#CE9178;">item.course</span>).
-For platform-type items:
+- In this section, the items of type: `item.platform` and `item.course` are displayed.  
+#### For platform-type items:
   - :one: You can access the platforms you have previously registered by clicking or pressing them.
   - :two: The number of notifications contained in the platforms will be indicated and colored depending on the quantity:
-    - <span style="background-color:#62c51e;color:#262628;"><strong>Green</strong></span>: This color indicates that there are no pending notifications on the platform, low alert.
-    - <span style="background-color:#0c2e93;color:#ffffff;"><strong>Blue</strong></span>: This color indicates a medium number of notifications, 1-3, medium alert.
-    - <span style="background-color:#ff2323;color:#ffffff;"><strong>Red</strong></span>: This color indicates the highest number of notifications, high alert.
-    >*The colors are extracted from the design guide in the documentation*
+    - `Green`: This color indicates that there are no pending notifications on the platform, low alert.
+    - `Blue`: This color indicates a medium number of notifications, 1-3, medium alert.
+    - `Red`: This color indicates the highest number of notifications, high alert.
+    >*The colors can be extracted from the design guide in the documentation*
   - :three: In the upper left corner, information about the platform's status will be displayed:
-    - <span style="background-color:#3bac31;color:#262628;"><strong>Green</strong></span>: Online, the platform is functioning correctly and can be accessed without problems.
-    - <span style="background-color:#ffde66;color:#262628;"><strong>Yellow</strong></span>: The platform is under maintenance, it cannot be accessed because it is being worked on. Normally, students are notified before this happens.
-    - <span style="background-color:#e66e34;color:#262628"><strong>Orange</strong></span>: The platform is out of service due to an unspecified problem. The user cannot access the platform because it is out of service.
-     >*The colors are extracted from the design guide in the documentation*
-  - :four: The platform's logo is displayed.
-  - :five: The platform's name is displayed.
-  - :six: A brief description of the platform is displayed.
-
- - For course-type items:
+    - `Green`: Online, the platform is functioning correctly and can be accessed without problems.
+    - `Yellow`: The platform is under maintenance, it cannot be accessed because it is being worked on. Normally, students are notified before this happens.
+    - `Orange`: The platform is out of service due to an unspecified problem. The user cannot access the platform because it is out of service.
+     >*The colors can be extracted from the design guide in the documentation*
+  - :four: The platform's name is displayed.
+  - :five: The `item.platform` can be of two types:  
+    - `Based.moodle`: This is the standard platform type, and all the information will be displayed.  
+    - `NonBased.moodle`: This type of platform cannot display the status of the platform or the number of notifications. It can only redirect the user to the specified URL.  
+    
+#### For course-type items:
    - :one: The characteristics :two:, :three:, and :five: from `items.platform` are inherited.
    - :two: The course name is displayed.
    - :three: The semester number of the course is displayed.
    - The name of the professor in charge of the course is displayed.
 - The items can be searched and filtered as specified in [`RF-03`].
 
-Sure, here's the translation:
+#### Modes
+The home section is divided into two modes: `course.mode` and `platform.mode`. Depending on which is activated, specific items will be displayed. By default, the courses mode will be shown whenever the user clicks on the home button. If the user wants to view the platforms, they must press the switch-type button to change to platform mode.
+
+- The default mode can be changed in the settings menu. By default, this option will be set to course mode.
+- When the user adds a platform through the add platform section, they will be redirected to the Home section in `platform.mode`.
+#### Settings Menu
+This menu can be accessed through the user icon in the application. The available options are:
+- Default mode, and
+- Log out.
 
 ### Add Platform
 - The user can access this section through the right button on the action bar.
-- In this section, platforms can be added by entering the URL in a text field indicated on the platform. The application will detect the platform and create the item that will be displayed in the home page section.
+- In this section, platforms can be added by entering the URL in a text field indicated on the application. The application will detect the platform and create the item that will be displayed in the home page section in the platform mode.
 - The platform will use the credentials previously entered when the user first logged in (`institutional email`). If the entered platform requires a username and password different from the institutional email, the application will ask for the email or username and password to log in, and if necessary, a captcha.
 - The first time the user logs into the application, the add platform section will be displayed, and the others will be locked until the process of adding a platform is completed.
 ## UADY HUB's data behavior:
@@ -131,58 +140,33 @@ erDiagram
     PLATFORM_ITEM ||--o{ EXAM : contains
     PLATFORM_ITEM ||--o{ NEWS : contains
 ```
-
-[`RF-03`]: https://github.com/Ozia112/Team-2-FSE-repo/blob/FIS-Project-Stage-3/PD/PD2/OrtizIsaac.md
-
-
-
-# Artifacts 
-- User Story:
+## Artifacts 
+### User Story:
 As a user, I want to quickly access different sections of the application through the Activity Bar to improve my workflow.
 
 
-- Acceptance Criteria:
-    - The Activity Bar must contain icons for the main sections of the application.
+### Acceptance Criteria:
+  - The Activity Bar must contain icons for the main sections of the application.
 
-    - Clicking on an icon should change the view to that section.
+  - Clicking on an icon should change the view to that section.
 
-- Use Case:
+### Use Case:
 
-User: Person using the application and navigating through the Activity Bar.
+`User`: Person using the application and navigating through the Activity Bar.
 
-- Scenario:
+#### Scenarios:
 
-**Scenario 1**: Successful Navigation
+- **Scenario 1**: Successful Navigation
 
-Context: The user is on the main screen of the application.
+  - `Context`: The user is on the main screen of the application.
 
-Actions:
+  - `Actions`:
 
-The user clicks on an icon in the Activity Bar.
+    - The user clicks on an icon in the Activity Bar.
 
-Expected Result: The application changes to the corresponding view, and the user can interact with that section.
+  - `Expected Result`: The application changes to the corresponding view, and the user can interact with that section.
 
-**Scenario** 2: Icon Customization
+> Description section written by `TM-01`  
+> Artifacts section written by `TM-02`
 
-Context: The user wants to customize the Activity Bar.
-
-Actions:
-
-The user opens the settings menu of the Activity Bar.
-
-The user drags and drops icons to rearrange them.
-
-The user hides some icons.
-
-Expected Result: The Activity Bar updates according to the user's preferences, and changes are reflected immediately.
-
-Scenario 3: Personalized Activity Bar on Start
-
-Context: The user has previously customized the Activity Bar.
-
-Actions:
-
-The user opens the application.
-
-Expected Result: The Activity Bar displays the icons in the user's customized arrangement.
-> Written by `TM-02`
+[`RF-03`]: https://github.com/Ozia112/Team-2-FSE-repo/blob/department.Product/Requirements/(C)Requirements/FunctionalRequirements/RF-03_FilterSearchBar.md


### PR DESCRIPTION
## RF-02_ActionBar
- Gramatical corrections
- Eliminate color text code by html because github dont render the text
- Add Base.moodle and NonBaseMoodle in the item.platforms
- Modes section added:
   - course.mode
   - platform.mode
- Setting menu section added:
   - Default mode
   - Log out
- Correct format documenttion for artifacts and subsections
- Delete scenarios 2 and 3
- Correct link to [`RF-03`] -Add and correct credits to TM-01 and TM-02